### PR TITLE
Change commands for mariadb & support dump

### DIFF
--- a/.docker-mate/utils/mysql-backup.sh
+++ b/.docker-mate/utils/mysql-backup.sh
@@ -22,6 +22,6 @@ fi
 if [[ "${backupOK,,}" == "yes" ]] || [[ "${backupOK,,}" == "y" ]]; then
     bash .docker-mate/utils/message.sh info "Creating a backup of your database in backup/mysql.sql.gz"
     mkdir -p backup
-    docker compose exec db mysqldump -u "${DB_USER}" -p"${DB_PASSWORD}" "${DB_NAME}" | gzip >"backup/mysql.sql.gz"
+    docker compose exec db mariadb-dump -u "${DB_USER}" -p"${DB_PASSWORD}" "${DB_NAME}" | gzip >"backup/mysql.sql.gz"
     bash .docker-mate/utils/message.sh success "Backup successful!"
 fi

--- a/.docker-mate/utils/mysql-restore.sh
+++ b/.docker-mate/utils/mysql-restore.sh
@@ -5,9 +5,13 @@ if ! docker ps -q --no-trunc | grep -q "$(docker compose ps -q db)"; then
     exit
 fi
 
+if [[ -f "$1" ]]; then
+    zcat "$1" | docker exec -i "$(docker compose ps -q db)" mariadb -u "${DB_USER}" -p"${DB_PASSWORD}" "${DB_NAME}"
+fi
+
 if [[ -f "./backup/mysql.sql.gz" ]]; then
     bash .docker-mate/utils/message.sh info "Restoring ./backup/mysql.sql.gz"
-    zcat "backup/mysql.sql.gz" | docker exec -i "$(docker compose ps -q db)" mysql -u "${DB_USER}" -p"${DB_PASSWORD}" "${DB_NAME}"
+    zcat "backup/mysql.sql.gz" | docker exec -i "$(docker compose ps -q db)" mariadb -u "${DB_USER}" -p"${DB_PASSWORD}" "${DB_NAME}"
     bash .docker-mate/utils/message.sh success "Restore successful!"
 else
     bash .docker-mate/utils/message.sh info "No backup found: backup/mysql.sql.gz"

--- a/Makefile
+++ b/Makefile
@@ -142,7 +142,7 @@ mysql-backup: ## Backup MySQL Database into backup folder
 	bash .docker-mate/utils/mysql-backup.sh
 
 mysql-restore: ## Restore MySQL Database from backup folder
-	bash .docker-mate/utils/mysql-restore.sh
+	bash .docker-mate/utils/mysql-restore.sh $(ARGS)
 
 ##:##########################
 # Utility: ##


### PR DESCRIPTION
## Description
- mariadb uses now its own name and mysqldump s gone...
- Add support for SQL file as argument

## Motivation and Context
Working tools :)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- Add info about the argument
- [ ] I have opened a Pull Request to update the documentation accordingly.
